### PR TITLE
Add SimC option dropdowns for fight style, bosses, and fight length

### DIFF
--- a/raidlocal/frontend/app.js
+++ b/raidlocal/frontend/app.js
@@ -193,17 +193,17 @@ const FIGHT_STYLE_OPTIONS = [
 ];
 
 const RAID_BUFF_OPTIONS = [
-  "bloodlust",
-  "arcane_intellect",
-  "power_word_fortitude",
-  "mark_of_the_wild",
-  "battle_shout",
-  "mystic_touch",
-  "chaos_brand",
-  "skyfury",
-  "hunters_mark",
-  "power_infusion",
-  "bleeding",
+  { id: "bloodlust", opt: "override.bloodlust" },
+  { id: "arcane_intellect", opt: "override.arcane_intellect" },
+  { id: "power_word_fortitude", opt: "override.power_word_fortitude" },
+  { id: "mark_of_the_wild", opt: "override.mark_of_the_wild" },
+  { id: "battle_shout", opt: "override.battle_shout" },
+  { id: "mystic_touch", opt: "override.mystic_touch" },
+  { id: "chaos_brand", opt: "override.chaos_brand" },
+  { id: "windfury_totem", opt: "override.windfury_totem" },
+  { id: "hunters_mark", opt: "override.hunters_mark" },
+  { id: "power_infusion", opt: "external_buffs.power_infusion" },
+  { id: "bleeding", opt: "override.bleeding" },
 ];
 
 function populateSimOptions(){
@@ -247,9 +247,9 @@ function collectSimcOptions(){
   if(bc && bc.value) opts.push(`desired_targets=${bc.value}`);
   const fl = document.getElementById("fightLength");
   if(fl && fl.value) opts.push(`max_time=${fl.value}`);
-  RAID_BUFF_OPTIONS.forEach(id => {
+  RAID_BUFF_OPTIONS.forEach(({ id, opt }) => {
     const el = document.getElementById(id);
-    if(el) opts.push(`${id}=${el.checked ? 1 : 0}`);
+    if (el) opts.push(`${opt}=${el.checked ? 1 : 0}`);
   });
   return opts;
 }

--- a/raidlocal/frontend/app.js
+++ b/raidlocal/frontend/app.js
@@ -192,6 +192,20 @@ const FIGHT_STYLE_OPTIONS = [
   "Ultraxion"
 ];
 
+const RAID_BUFF_OPTIONS = [
+  "bloodlust",
+  "arcane_intellect",
+  "power_word_fortitude",
+  "mark_of_the_wild",
+  "battle_shout",
+  "mystic_touch",
+  "chaos_brand",
+  "skyfury",
+  "hunters_mark",
+  "power_infusion",
+  "bleeding",
+];
+
 function populateSimOptions(){
   const fs = document.getElementById("fightStyle");
   if(fs){
@@ -233,6 +247,10 @@ function collectSimcOptions(){
   if(bc && bc.value) opts.push(`desired_targets=${bc.value}`);
   const fl = document.getElementById("fightLength");
   if(fl && fl.value) opts.push(`max_time=${fl.value}`);
+  RAID_BUFF_OPTIONS.forEach(id => {
+    const el = document.getElementById(id);
+    if(el) opts.push(`${id}=${el.checked ? 1 : 0}`);
+  });
   return opts;
 }
 

--- a/raidlocal/frontend/app.js
+++ b/raidlocal/frontend/app.js
@@ -200,7 +200,7 @@ const RAID_BUFF_OPTIONS = [
   { id: "battle_shout", opt: "override.battle_shout" },
   { id: "mystic_touch", opt: "override.mystic_touch" },
   { id: "chaos_brand", opt: "override.chaos_brand" },
-  { id: "windfury_totem", opt: "override.windfury_totem" },
+  { id: "windfury_totem", opt: "override.windfury" },
   { id: "hunters_mark", opt: "override.hunters_mark" },
   { id: "power_infusion", opt: "external_buffs.power_infusion" },
   { id: "bleeding", opt: "override.bleeding" },

--- a/raidlocal/frontend/index.html
+++ b/raidlocal/frontend/index.html
@@ -17,6 +17,16 @@
       <h2>Quick Sim</h2>
       <textarea id="simcInput" placeholder="Paste /simc addon export or .simc profile here"></textarea>
       <input id="extraArgs" placeholder="iterations=5000,threads=8" />
+
+      <label class="lbl">Fight Style</label>
+      <select id="fightStyle"></select>
+
+      <label class="lbl">Number of Bosses</label>
+      <select id="bossCount"></select>
+
+      <label class="lbl">Fight Length</label>
+      <select id="fightLength"></select>
+
       <button id="runQuickSim">Run Quick Sim</button>
       <div id="quickSimStatus" class="status"></div>
       <div id="quickSimResult" class="result"></div>

--- a/raidlocal/frontend/index.html
+++ b/raidlocal/frontend/index.html
@@ -6,7 +6,7 @@
   <title>RaidLocal</title>
 
   <!-- Styles (cache-busted) -->
-  <link rel="stylesheet" href="/frontend/styles.css?v=3">
+  <link rel="stylesheet" href="/frontend/styles.css?v=4">
 </head>
 <body>
   <div class="container">
@@ -16,14 +16,20 @@
     <section class="card">
       <h2>Simulation Options</h2>
 
-      <label class="lbl">Fight Style</label>
-      <select id="fightStyle"></select>
-
-      <label class="lbl">Number of Bosses</label>
-      <select id="bossCount"></select>
-
-      <label class="lbl">Fight Length</label>
-      <select id="fightLength"></select>
+      <div class="row sim-options">
+        <div>
+          <label class="lbl">Fight Style</label>
+          <select id="fightStyle"></select>
+        </div>
+        <div>
+          <label class="lbl">Number of Bosses</label>
+          <select id="bossCount"></select>
+        </div>
+        <div>
+          <label class="lbl">Fight Length</label>
+          <select id="fightLength"></select>
+        </div>
+      </div>
 
       <label class="lbl">Raid Buffs</label>
       <div class="raid-buffs">

--- a/raidlocal/frontend/index.html
+++ b/raidlocal/frontend/index.html
@@ -34,7 +34,7 @@
         <label class="switch"><input type="checkbox" id="battle_shout" checked /> Battle Shout</label>
         <label class="switch"><input type="checkbox" id="mystic_touch" checked /> Mystic Touch (5% Physical Damage)</label>
         <label class="switch"><input type="checkbox" id="chaos_brand" checked /> Chaos Brand (3% Magic Damage)</label>
-        <label class="switch"><input type="checkbox" id="skyfury" checked /> Skyfury</label>
+        <label class="switch"><input type="checkbox" id="windfury_totem" checked /> Windfury Totem</label>
         <label class="switch"><input type="checkbox" id="hunters_mark" checked /> Hunter's Mark</label>
         <label class="switch"><input type="checkbox" id="power_infusion" checked /> Power Infusion (Beta)</label>
         <label class="switch"><input type="checkbox" id="bleeding" checked /> Bleeding</label>
@@ -108,6 +108,6 @@
   </div>
 
   <!-- App (cache-busted to avoid stale JS) -->
-  <script src="/frontend/app.js?v=7"></script>
+  <script src="/frontend/app.js?v=8"></script>
 </body>
 </html>

--- a/raidlocal/frontend/index.html
+++ b/raidlocal/frontend/index.html
@@ -24,6 +24,21 @@
 
       <label class="lbl">Fight Length</label>
       <select id="fightLength"></select>
+
+      <label class="lbl">Raid Buffs</label>
+      <div class="raid-buffs">
+        <label class="switch"><input type="checkbox" id="bloodlust" checked /> Bloodlust</label>
+        <label class="switch"><input type="checkbox" id="arcane_intellect" checked /> Arcane Intellect</label>
+        <label class="switch"><input type="checkbox" id="power_word_fortitude" checked /> Power Word: Fortitude</label>
+        <label class="switch"><input type="checkbox" id="mark_of_the_wild" checked /> Mark of the Wild</label>
+        <label class="switch"><input type="checkbox" id="battle_shout" checked /> Battle Shout</label>
+        <label class="switch"><input type="checkbox" id="mystic_touch" checked /> Mystic Touch (5% Physical Damage)</label>
+        <label class="switch"><input type="checkbox" id="chaos_brand" checked /> Chaos Brand (3% Magic Damage)</label>
+        <label class="switch"><input type="checkbox" id="skyfury" checked /> Skyfury</label>
+        <label class="switch"><input type="checkbox" id="hunters_mark" checked /> Hunter's Mark</label>
+        <label class="switch"><input type="checkbox" id="power_infusion" checked /> Power Infusion (Beta)</label>
+        <label class="switch"><input type="checkbox" id="bleeding" checked /> Bleeding</label>
+      </div>
     </section>
 
     <!-- Quick Sim (unchanged) -->
@@ -93,6 +108,6 @@
   </div>
 
   <!-- App (cache-busted to avoid stale JS) -->
-  <script src="/frontend/app.js?v=6"></script>
+  <script src="/frontend/app.js?v=7"></script>
 </body>
 </html>

--- a/raidlocal/frontend/index.html
+++ b/raidlocal/frontend/index.html
@@ -12,11 +12,9 @@
   <div class="container">
     <h1>RaidLocal</h1>
 
-    <!-- Quick Sim (unchanged) -->
+    <!-- Simulation Options -->
     <section class="card">
-      <h2>Quick Sim</h2>
-      <textarea id="simcInput" placeholder="Paste /simc addon export or .simc profile here"></textarea>
-      <input id="extraArgs" placeholder="iterations=5000,threads=8" />
+      <h2>Simulation Options</h2>
 
       <label class="lbl">Fight Style</label>
       <select id="fightStyle"></select>
@@ -26,6 +24,13 @@
 
       <label class="lbl">Fight Length</label>
       <select id="fightLength"></select>
+    </section>
+
+    <!-- Quick Sim (unchanged) -->
+    <section class="card">
+      <h2>Quick Sim</h2>
+      <textarea id="simcInput" placeholder="Paste /simc addon export or .simc profile here"></textarea>
+      <input id="extraArgs" placeholder="iterations=5000,threads=8" />
 
       <button id="runQuickSim">Run Quick Sim</button>
       <div id="quickSimStatus" class="status"></div>

--- a/raidlocal/frontend/styles.css
+++ b/raidlocal/frontend/styles.css
@@ -3,6 +3,7 @@ body{font-family:system-ui;background:#0b0f17;color:#e8edf2;margin:0}
 .card{background:#111827;border:1px solid #1f2937;border-radius:16px;padding:16px;margin:18px 0}
 textarea{width:100%;height:160px;background:#0d131c;color:#e8edf2;border:1px solid #263241;border-radius:8px;padding:10px;font-family:ui-monospace,Consolas,monospace}
 input{width:100%;background:#0d131c;color:#e8edf2;border:1px solid #263241;border-radius:8px;padding:10px;margin:8px 0}
+select{width:100%;background:#0d131c;color:#e8edf2;border:1px solid #263241;border-radius:8px;padding:10px;margin:8px 0}
 button{background:#2563eb;color:#fff;border:none;border-radius:10px;padding:10px 14px;cursor:pointer}
 button:hover{background:#1e40af}
 .status{margin-top:8px;font-size:14px;color:#9fb3c8}
@@ -27,6 +28,10 @@ a.button{display:inline-block;margin:6px 0;color:#93c5fd}
 .tg-controls .spacer{flex:1}
 .switch{display:flex;gap:6px;align-items:center;margin:0 6px;color:#b9c7d8;font-size:13px}
 .ghost{background:transparent;border:1px solid #314357;color:#b9c7d8}
+
+.row.sim-options>div{flex:1}
+.raid-buffs{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:4px 12px;margin:4px 0}
+.raid-buffs .switch{margin:0}
 
 /* Result table shell */
 .tg-table{border:1px solid #263241;border-radius:12px;overflow:hidden;margin-top:8px}


### PR DESCRIPTION
## Summary
- add fight style, boss count, and fight length dropdowns to Quick Sim
- populate options from SimulationCraft and append to sim args
- include new options in Quick Sim and Top Gear requests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab8b1f164883259ad9ffbbd97fa0d4